### PR TITLE
specify version with egison/egison-package-builder revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This action sets up a [Egison](https://www.egison.org) environment for use in actions by:
 
 - optionally installing a version of egison and adding to PATH.
-- Note that this action only support linux OS and [egison versions released by egison-package-builder](https://github.com/egison/egison-package-builder/releases).
+- Note that this action only support linux OS.
 
 ## Usage
 
@@ -43,6 +43,11 @@ jobs:
           egison-version: ${{ matrix.egison }}
       - run: egison --version
 ```
+
+Supported versions:
+
+- `3.10.3`
+- `3.9.4`
 
 ## License
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -38,7 +38,8 @@ exports.findEgisonVersion = findEgisonVersion;
 function _findEgisonVersionForLinux(baseInstallDir, version) {
     return __awaiter(this, void 0, void 0, function* () {
         var tmpOutput = baseInstallDir + '/egison.deb';
-        var debUrl = `https://raw.githubusercontent.com/egison/egison-package-builder/${version}/packages/egison.x86_64.deb`;
+        var revision = _packageRevisionOf(version);
+        var debUrl = `https://raw.githubusercontent.com/egison/egison-package-builder/${revision}/packages/egison.x86_64.deb`;
         yield exec.exec(`wget -O ${tmpOutput} ${debUrl}`);
         if (fs.existsSync(tmpOutput)) {
             yield exec.exec(`sudo dpkg -i ${tmpOutput}`);
@@ -48,4 +49,14 @@ function _findEgisonVersionForLinux(baseInstallDir, version) {
         }
         yield io.rmRF(tmpOutput);
     });
+}
+function _packageRevisionOf(version) {
+    switch (version) {
+        case '3.10.3':
+            return '744e59bf2ac0828ed45ed71ff81cf29c2c2f0fca';
+        case '3.9.4':
+            return '3418c471b9a9649dc1e46cd2e23c09b0c04da7d9';
+        default:
+            throw new Error(`unsupported egison ${version}`);
+    }
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -25,7 +25,8 @@ async function _findEgisonVersionForLinux(
   version: string
 ) {
   var tmpOutput = baseInstallDir + '/egison.deb';
-  var debUrl = `https://raw.githubusercontent.com/egison/egison-package-builder/${version}/packages/egison.x86_64.deb`;
+  var revision = _packageRevisionOf(version);
+  var debUrl = `https://raw.githubusercontent.com/egison/egison-package-builder/${revision}/packages/egison.x86_64.deb`;
   await exec.exec(`wget -O ${tmpOutput} ${debUrl}`);
   if (fs.existsSync(tmpOutput)) {
     await exec.exec(`sudo dpkg -i ${tmpOutput}`);
@@ -33,4 +34,15 @@ async function _findEgisonVersionForLinux(
     throw new Error(`cannot download egison ${version}`);
   }
   await io.rmRF(tmpOutput);
+}
+
+function _packageRevisionOf(version: string) {
+  switch (version) {
+    case '3.10.3':
+      return '744e59bf2ac0828ed45ed71ff81cf29c2c2f0fca';
+    case '3.9.4':
+      return '3418c471b9a9649dc1e46cd2e23c09b0c04da7d9';
+    default:
+      throw new Error(`unsupported egison ${version}`);
+  }
 }


### PR DESCRIPTION
egison/egison-package-builder  is different tag version and egison version.

see: https://github.com/matsubara0507/setup-egison/runs/501283551

reason is relesae script dump version before release deb.
therefore, I used egison-package-builder revision copatible egison version.