### PR TITLE
Remove branch random suffix in auto update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,4 +43,3 @@ jobs:
         labels: New Egison Version
         branch: egison-version-${{ steps.latest.outputs.version }}
         base: master
-        branch-suffix: random


### PR DESCRIPTION
This random branch suffix create duplicated PR for same new version.